### PR TITLE
Removed is_connected() for vero vertex graph

### DIFF
--- a/LAB_4/steve/stevetest.in
+++ b/LAB_4/steve/stevetest.in
@@ -14,9 +14,6 @@ delete
 new: 1
 is_connected 1
 delete
-new: 0
-is_connected 0
-delete
 new: 50
 insert 5 10 4.4
 insert 10 5 0


### PR DESCRIPTION
TAs have notified us that they won't consider the case where the graph has zero vertices. Thus, I have removed some lines from the test case where it involved a graph with 0 vertices.